### PR TITLE
Use cmd abbreviation instead of command on OSX

### DIFF
--- a/luigi/shortcut.lua
+++ b/luigi/shortcut.lua
@@ -25,7 +25,7 @@ end
 
 function Shortcut.expandAliases (value)
     return value
-        :gsub('%f[%a]command%-', 'mac-gui-')
+        :gsub('%f[%a]cmd%-', 'mac-gui-')
         :gsub('%f[%a]option%-', 'mac-alt-')
 end
 
@@ -72,8 +72,9 @@ function Shortcut.stringify (shortcut)
         if Shortcut.appliesToPlatform(value) then
             if isMac then
                 value = value
-                    :gsub('%f[%a]c%-', 'command-')
-                    :gsub('%f[%a]gui%-', 'command-')
+                    :gsub('%f[%a]c%-', 'cmd-')
+                    :gsub('%f[%a]gui%-', 'cmd-')
+                    :gsub('%f[%a]command%-', 'cmd-')
                     :gsub('%f[%a]alt%-', 'option-')
             else
                 value = value


### PR DESCRIPTION
This is how it is usually done in OSX programs.

![screenshot 2016-01-31 12 59 02](https://cloud.githubusercontent.com/assets/11627131/12701987/715a1834-c81a-11e5-8c91-6d7cc5281549.png)
