### PR TITLE
Fix: Can't set scissor with negative width and/or height.

### DIFF
--- a/luigi/widget.lua
+++ b/luigi/widget.lua
@@ -711,7 +711,11 @@ function Widget:getRectangle (useMargin, usePadding)
     if usePadding then
         shrink(self.padding or 0)
     end
-    return math.floor(x), math.floor(y), math.floor(w), math.floor(h)
+    x = math.max(math.floor(x),0)
+    y = math.max(math.floor(y),0)
+    w = math.max(math.floor(w),0)
+    h = math.max(math.floor(h),0)
+    return x, y, w, h
 end
 
 --[[--


### PR DESCRIPTION
Small fix for

```sh
Error: luigi/widget/text.lua:414: Can't set scissor with negative width and/or height.
stack traceback:
	[love "boot.lua"]:352: in function <[love "boot.lua"]:348>
	[C]: in function 'intersectScissor'
	luigi/widget/text.lua:414: in function 'func'
	luigi/hooker.lua:79: in function 'callbacks'
	luigi/event.lua:16: in function 'emit'
	luigi/painter.lua:234: in function 'paint'
	luigi/painter.lua:204: in function 'paintChildren'
	luigi/painter.lua:229: in function 'defaultAction'
	luigi/event.lua:18: in function 'emit'
	...
	luigi/painter.lua:204: in function 'paintChildren'
	luigi/painter.lua:229: in function 'defaultAction'
	luigi/event.lua:18: in function 'emit'
	luigi/painter.lua:215: in function 'paint'
	luigi/input.lua:19: in function 'handleDisplay'
	luigi/backend/love.lua:138: in function 'func'
	luigi/hooker.lua:79: in function 'draw'
	[love "callbacks.lua"]:168: in function <[love "callbacks.lua"]:144>
	[C]: in function 'xpcall'
```
Sometime width coord is negative. 
Im just lock minimal size/pose to zero. 